### PR TITLE
v2.2.0 Release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,12 @@ CAPCUT_SPEAKER_PREVIEW_TEMP_DIR=speaker-preview-temp
 CAPCUT_SPEAKER_PREVIEW_TEXT=こんにちは、これは話者プレビューです。
 CAPCUT_SPEAKER_PREVIEW_MAX_AGE_DAYS=14
 
+# TTS chunking
+# upstream の読み上げ上限を避けるため、長文はこの文字数以内で分割して並列生成する
+CAPCUT_TTS_TEXT_CHUNK_MAX_LENGTH=500
+# 区切り文字を探し始める位置。0.6 なら上限文字数の 60% 以降から探す
+# CAPCUT_TTS_TEXT_CHUNK_BOUNDARY_SEARCH_RATIO=0.6
+
 # Node Setting
 LOG_LEVEL=info
 ERROR_HANDLE=true

--- a/README.en.md
+++ b/README.en.md
@@ -249,6 +249,8 @@ Main environment variables are listed below.
 | `CAPCUT_SPEAKER_PREVIEW_TEMP_DIR` | Directory used to cache speaker preview audio |
 | `CAPCUT_SPEAKER_PREVIEW_TEXT` | Text used to generate preview audio |
 | `CAPCUT_SPEAKER_PREVIEW_MAX_AGE_DAYS` | Preview regeneration threshold in days |
+| `CAPCUT_TTS_TEXT_CHUNK_MAX_LENGTH` | Maximum text length for each long-form TTS chunk |
+| `CAPCUT_TTS_TEXT_CHUNK_BOUNDARY_SEARCH_RATIO` | Ratio where boundary search starts inside each TTS chunk |
 | `LEGACY_CAPCUT_API_URL` | Base URL for the old token API |
 | `LEGACY_BYTEINTL_API_URL` | Base URL for the old websocket endpoint |
 | `LEGACY_DEVICE_TIME` | Device-Time sent to the old token API |

--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ GET と同じフィールドを JSON body で送信します。
 | `CAPCUT_SPEAKER_PREVIEW_TEMP_DIR` | 話者プレビュー音声キャッシュの保存先 |
 | `CAPCUT_SPEAKER_PREVIEW_TEXT` | プレビュー生成時に読み上げるテキスト |
 | `CAPCUT_SPEAKER_PREVIEW_MAX_AGE_DAYS` | プレビュー再生成までの日数 |
+| `CAPCUT_TTS_TEXT_CHUNK_MAX_LENGTH` | 長文 TTS を分割する最大文字数 |
+| `CAPCUT_TTS_TEXT_CHUNK_BOUNDARY_SEARCH_RATIO` | 区切り文字を探し始める位置の割合 |
 | `LEGACY_CAPCUT_API_URL` | 旧 token API のベース URL |
 | `LEGACY_BYTEINTL_API_URL` | 旧 WebSocket 接続先のベース URL |
 | `LEGACY_DEVICE_TIME` | 旧 token API に送る Device-Time |

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3,7 +3,7 @@ openapi: 3.0.1
 info:
   title: CapCut TTS Proxy
   description: CapCut Web の session を維持しながら音声生成を行うラッパー API
-  version: 2.1.0
+  version: 2.2.0
 
 servers:
   - url: http://localhost:8080

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "capcut-tts",
-  "version": "1.3.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "capcut-tts",
-      "version": "1.3.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "cors": "^2.8.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "capcut-tts",
   "description": "CapCut TTS API を扱いやすくする Express ベースのラッパープロキシ",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "author": "",
   "keywords": [
     "typescript",

--- a/src/configs/env.ts
+++ b/src/configs/env.ts
@@ -69,6 +69,16 @@ const envSchema = z
       .number()
       .positive()
       .default(14),
+    CAPCUT_TTS_TEXT_CHUNK_MAX_LENGTH: z.coerce
+      .number()
+      .int()
+      .positive()
+      .default(100),
+    CAPCUT_TTS_TEXT_CHUNK_BOUNDARY_SEARCH_RATIO: z.coerce
+      .number()
+      .positive()
+      .max(1)
+      .default(0.6),
     LEGACY_CAPCUT_API_URL: z
       .string()
       .url()

--- a/src/lib/string.ts
+++ b/src/lib/string.ts
@@ -1,0 +1,124 @@
+/**
+ * ### splitTtsText
+ * TTS の文字数上限に合わせてテキストを分割する
+ *
+ * @param text - 分割対象のテキスト
+ * @param maxLength - 1 チャンクあたりの最大文字数
+ * @param boundarySearchRatio - 区切り文字を探し始める割合
+ * @returns 分割済みテキスト
+ */
+export const splitTtsText = (
+  text: string,
+  maxLength: number,
+  boundarySearchRatio: number
+): string[] => {
+  const normalizedText = text.trim();
+  const textCharacters = Array.from(normalizedText);
+
+  if (textCharacters.length <= maxLength) {
+    return [normalizedText];
+  }
+
+  const chunks: string[] = [];
+  let startIndex = 0;
+
+  while (startIndex < textCharacters.length) {
+    const remainingLength = textCharacters.length - startIndex;
+    if (remainingLength <= maxLength) {
+      const tailChunk = textCharacters.slice(startIndex).join('').trim();
+      if (tailChunk) {
+        chunks.push(tailChunk);
+      }
+      break;
+    }
+
+    const splitLength = resolveTtsChunkLength(
+      textCharacters,
+      startIndex,
+      maxLength,
+      boundarySearchRatio
+    );
+    const chunk = textCharacters
+      .slice(startIndex, startIndex + splitLength)
+      .join('')
+      .trim();
+    if (chunk) {
+      chunks.push(chunk);
+    }
+
+    startIndex += splitLength;
+    while (
+      startIndex < textCharacters.length &&
+      isTtsChunkSeparator(textCharacters[startIndex])
+    ) {
+      startIndex += 1;
+    }
+  }
+
+  return chunks.length > 0 ? chunks : [normalizedText];
+};
+
+/**
+ * ### resolveTtsChunkLength
+ * 境界らしい箇所を優先して切り出し長を決める
+ *
+ * @param textCharacters - 文字単位に分割済みのテキスト
+ * @param startIndex - 切り出し開始位置
+ * @param maxLength - 1 チャンクあたりの最大文字数
+ * @param boundarySearchRatio - 区切り文字を探し始める割合
+ * @returns 切り出す文字数
+ */
+const resolveTtsChunkLength = (
+  textCharacters: string[],
+  startIndex: number,
+  maxLength: number,
+  boundarySearchRatio: number
+): number => {
+  const endIndex = Math.min(textCharacters.length, startIndex + maxLength);
+  const preferredBoundaryIndex = Math.max(
+    startIndex + 1,
+    startIndex + Math.floor(maxLength * boundarySearchRatio)
+  );
+
+  for (let cursor = endIndex - 1; cursor >= preferredBoundaryIndex; cursor -= 1) {
+    if (isStrongTtsChunkBoundary(textCharacters[cursor])) {
+      return cursor - startIndex + 1;
+    }
+  }
+
+  for (let cursor = endIndex - 1; cursor >= preferredBoundaryIndex; cursor -= 1) {
+    if (isWeakTtsChunkBoundary(textCharacters[cursor])) {
+      return cursor - startIndex + 1;
+    }
+  }
+
+  return endIndex - startIndex;
+};
+
+const isTtsChunkSeparator = (value: string) =>
+  value === '\n' ||
+  value === '\r' ||
+  value === ' ' ||
+  value === '\t' ||
+  value === '\u3000';
+
+const isStrongTtsChunkBoundary = (value: string) =>
+  value === '\n' ||
+  value === '\r' ||
+  value === '。' ||
+  value === '！' ||
+  value === '？' ||
+  value === '!' ||
+  value === '?' ||
+  value === '．' ||
+  value === '.';
+
+const isWeakTtsChunkBoundary = (value: string) =>
+  isTtsChunkSeparator(value) ||
+  value === '、' ||
+  value === ',' ||
+  value === '，' ||
+  value === '；' ||
+  value === ';' ||
+  value === '：' ||
+  value === ':';

--- a/src/services/CapCutService.ts
+++ b/src/services/CapCutService.ts
@@ -19,6 +19,7 @@ import env from '@/configs/env';
 import { CookieJar } from '@/lib/capcut/cookieJar';
 import { capCutConstants } from '@/lib/capcut/constants';
 import { CapCutApiError, unwrapJsonResponse } from '@/lib/capcut/responseUtils';
+import { splitTtsText } from '@/lib/string';
 import {
   parseSpeaker,
   resolveSpeaker,
@@ -125,14 +126,36 @@ class CapCutService {
    * 音声をバッファとして取得する
    */
   async synthesizeBuffer(options: SynthesizeOptions): Promise<AudioResult> {
-    const response = await this.createAudioResponse(options);
-    const buffer = Buffer.from(await response.arrayBuffer());
+    const chunkedTexts = splitTtsText(
+      options.text,
+      env.CAPCUT_TTS_TEXT_CHUNK_MAX_LENGTH,
+      env.CAPCUT_TTS_TEXT_CHUNK_BOUNDARY_SEARCH_RATIO
+    );
+    if (chunkedTexts.length === 1) {
+      const response = await this.createAudioResponse(options);
+      const buffer = Buffer.from(await response.arrayBuffer());
+
+      return {
+        buffer,
+        contentType: response.headers.get('content-type') ?? 'audio/mpeg',
+        contentLength: response.headers.get('content-length') ?? undefined,
+        fileName: this.extractFileName(response),
+      };
+    }
+
+    const chunkedResults = await this.synthesizeChunkedBuffers(
+      options,
+      chunkedTexts
+    );
+    const buffer = Buffer.concat(
+      chunkedResults.map((chunkResult) => chunkResult.buffer)
+    );
 
     return {
       buffer,
-      contentType: response.headers.get('content-type') ?? 'audio/mpeg',
-      contentLength: response.headers.get('content-length') ?? undefined,
-      fileName: this.extractFileName(response),
+      contentType: chunkedResults[0]?.contentType ?? 'audio/mpeg',
+      contentLength: String(buffer.byteLength),
+      fileName: chunkedResults[0]?.fileName,
     };
   }
 
@@ -142,19 +165,35 @@ class CapCutService {
   async synthesizeStream(
     options: SynthesizeOptions
   ): Promise<AudioStreamResult> {
-    const response = await this.createAudioResponse(options);
+    const chunkedTexts = splitTtsText(
+      options.text,
+      env.CAPCUT_TTS_TEXT_CHUNK_MAX_LENGTH,
+      env.CAPCUT_TTS_TEXT_CHUNK_BOUNDARY_SEARCH_RATIO
+    );
+    if (chunkedTexts.length === 1) {
+      const response = await this.createAudioResponse(options);
 
-    if (!response.body) {
-      throw new Error('CapCut audio response did not contain a body');
+      if (!response.body) {
+        throw new Error('CapCut audio response did not contain a body');
+      }
+
+      return {
+        stream: Readable.fromWeb(
+          response.body as unknown as import('node:stream/web').ReadableStream
+        ),
+        contentType: response.headers.get('content-type') ?? 'audio/mpeg',
+        contentLength: response.headers.get('content-length') ?? undefined,
+        fileName: this.extractFileName(response),
+      };
     }
 
+    const audioResult = await this.synthesizeBuffer(options);
+
     return {
-      stream: Readable.fromWeb(
-        response.body as unknown as import('node:stream/web').ReadableStream
-      ),
-      contentType: response.headers.get('content-type') ?? 'audio/mpeg',
-      contentLength: response.headers.get('content-length') ?? undefined,
-      fileName: this.extractFileName(response),
+      stream: Readable.from([audioResult.buffer]),
+      contentType: audioResult.contentType,
+      contentLength: audioResult.contentLength,
+      fileName: audioResult.fileName,
     };
   }
 
@@ -1110,6 +1149,33 @@ class CapCutService {
     options: SynthesizeOptions
   ): Promise<Response> {
     return this.createAudioResponseWithRetry(options, true);
+  }
+
+  /**
+   * 分割したテキストを並列で音声化する
+   */
+  private async synthesizeChunkedBuffers(
+    options: SynthesizeOptions,
+    chunkedTexts: string[]
+  ): Promise<AudioResult[]> {
+    const chunkResults = await Promise.all(
+      chunkedTexts.map(async (chunkText) => {
+        const response = await this.createAudioResponse({
+          ...options,
+          text: chunkText,
+        });
+        const buffer = Buffer.from(await response.arrayBuffer());
+
+        return {
+          buffer,
+          contentType: response.headers.get('content-type') ?? 'audio/mpeg',
+          contentLength: response.headers.get('content-length') ?? undefined,
+          fileName: this.extractFileName(response),
+        };
+      })
+    );
+
+    return chunkResults;
   }
 
   /**


### PR DESCRIPTION
# v2.2.0 Release

# JP
## 概要

CapCut TTS の長文読み上げに対応するため、テキスト分割と並列生成を追加した小規模リリースです。

## 主な変更点

- 長文テキストを分割して非同期で生成するように変更
- 分割上限文字数を `CAPCUT_TTS_TEXT_CHUNK_MAX_LENGTH` で設定可能に追加
- 区切り位置の探索開始割合を `CAPCUT_TTS_TEXT_CHUNK_BOUNDARY_SEARCH_RATIO` で設定可能に追加

## 備考

- 既存の `/v2/synthesize` の使い方はそのままです
- 追加した設定は `.env.example` にも反映済み

# EN
## Summary

Small release for long-form CapCut TTS support with text chunking and parallel generation.

## Highlights

- Split long text and generate chunks asynchronously
- Added `CAPCUT_TTS_TEXT_CHUNK_MAX_LENGTH` for chunk size
- Added `CAPCUT_TTS_TEXT_CHUNK_BOUNDARY_SEARCH_RATIO` for boundary search start ratio

## Notes

- Existing `/v2/synthesize` usage stays the same
- New config values are also added to `.env.example`
